### PR TITLE
Set default Maia level to highest

### DIFF
--- a/example/src/app/batch/page.tsx
+++ b/example/src/app/batch/page.tsx
@@ -29,8 +29,8 @@ export default function Home() {
   >(
     openings.slice(0, count).map((fen) => ({
       fen,
-      selfElo: 1100,
-      oppoElo: 1100,
+      selfElo: 1900,
+      oppoElo: 1900,
       arrows: [],
     })),
   );
@@ -49,8 +49,8 @@ export default function Home() {
     setBoards(
       openings.slice(0, count).map((fen) => ({
         fen,
-        selfElo: 1100,
-        oppoElo: 1100,
+        selfElo: 1900,
+        oppoElo: 1900,
         arrows: [],
       })),
     );
@@ -60,8 +60,8 @@ export default function Home() {
     const start = performance.now();
     const evaluation = await model?.batchEvaluate(
       boards.map((b) => b.fen),
-      Array(BOARDS.length).fill(1100),
-      Array(BOARDS.length).fill(1100),
+      Array(BOARDS.length).fill(1900),
+      Array(BOARDS.length).fill(1900),
     );
 
     if (!evaluation) {

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -14,8 +14,8 @@ import Maia from "../../../maia2/dist/src/model";
 
 export default function Home() {
   const [loaded, setLoaded] = useState(false);
-  const [selfElo, setSelfElo] = useState(1100);
-  const [oppoElo, setOppoElo] = useState(1100);
+  const [selfElo, setSelfElo] = useState(1900);
+  const [oppoElo, setOppoElo] = useState(1900);
   const [board, setBoard] = useState<Chess>(
     new Chess("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"),
   );


### PR DESCRIPTION
## Summary
- default example UI to highest Elo bucket (1900) instead of 1100
- update batch demo defaults to 1900 as well

## Testing
- `npm run build` within `maia2` *(fails: Cannot find module 'onnxruntime-web')*
- `npm run build` within `example` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843118fadf483219fc7c1fe1889941f