### PR TITLE
Add Netlify and Cloudflare deploy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ You can deploy the demo with one click using the button below:
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/your-user/maia2-js)
 
 The link will clone this repository into a new Vercel project and automatically build the Next.js app. Replace `your-user` with your GitHub account if you fork the repo first.
+
+## Deploy to Netlify
+
+If you prefer using [Netlify](https://www.netlify.com/), you can deploy from this repository as well:
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository-url=https://github.com/your-user/maia2-js)
+
+Netlify reads the `netlify.toml` file and builds the app from the `example/` directory.
+
+## Deploy to Cloudflare Pages
+
+[Cloudflare Pages](https://pages.cloudflare.com/) also offers free hosting. When creating a project, set the root directory to `example` and follow [Cloudflare's Next.js guide](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/) for more details.

--- a/example/README.md
+++ b/example/README.md
@@ -36,3 +36,15 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/your-user/maia2-js)
+
+## Deploy on Netlify
+
+You can also host the example on [Netlify](https://www.netlify.com/). Use the button below to create a new Netlify project from your fork:
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository-url=https://github.com/your-user/maia2-js)
+
+Netlify reads the `netlify.toml` configuration at the repository root.
+
+## Deploy on Cloudflare Pages
+
+Another free option is [Cloudflare Pages](https://pages.cloudflare.com/). Connect your GitHub repository, set the project root to `example`, and follow [Cloudflare's Next.js guide](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/) for more information.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+  base = "example"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- add `netlify.toml` config for Netlify deploys
- document Netlify and Cloudflare deployment in both READMEs

## Testing
- `npm install` in `example`
- `npm run build` *(fails: Can't resolve 'onnxruntime-web')*

------
https://chatgpt.com/codex/tasks/task_e_6843343377dc8321879b20d88f362092