### PR TITLE
Fix deploy links for Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open <http://localhost:3000> to view the app.
 
 You can deploy the demo with one click using the button below:
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/your-user/maia2-js)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/kevinjosethomas/maia2-js)
 
 The link will clone this repository into a new Vercel project and automatically build the Next.js app. Replace `your-user` with your GitHub account if you fork the repo first.
 
@@ -26,7 +26,7 @@ The link will clone this repository into a new Vercel project and automatically 
 
 If you prefer using [Netlify](https://www.netlify.com/), you can deploy from this repository as well:
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository-url=https://github.com/your-user/maia2-js)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/kevinjosethomas/maia2-js)
 
 Netlify reads the `netlify.toml` file and builds the app from the `example/` directory.
 

--- a/example/README.md
+++ b/example/README.md
@@ -35,13 +35,13 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/your-user/maia2-js)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/kevinjosethomas/maia2-js)
 
 ## Deploy on Netlify
 
 You can also host the example on [Netlify](https://www.netlify.com/). Use the button below to create a new Netlify project from your fork:
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository-url=https://github.com/your-user/maia2-js)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/kevinjosethomas/maia2-js)
 
 Netlify reads the `netlify.toml` configuration at the repository root.
 


### PR DESCRIPTION
## Summary
- update README deploy buttons to use the correct `repository` query parameter for Netlify

## Testing
- `npm install` in `example`
- `npm run lint` in `example`


------
https://chatgpt.com/codex/tasks/task_e_6843418ee434832190bbd830b43a96f4